### PR TITLE
Revert "アクティビティ在庫シートで追加したタスクが、本日のTODOになるバグを修正"

### DIFF
--- a/app/javascript/packs/reducers/date.js
+++ b/app/javascript/packs/reducers/date.js
@@ -1,7 +1,4 @@
-let initialState = null
-if (location.pathname === '/todos') { initialState = window.date }
-
-const date = (state = initialState, action) => {
+const date = (state = window.date, action) => {
   switch (action.type) {
     case 'CHANGE_DATE':
       return action.date

--- a/app/views/activities/index.html.haml
+++ b/app/views/activities/index.html.haml
@@ -1,5 +1,6 @@
 %h2.text-center アクティビティ在庫シート
 #activityInventory
 = javascript_tag do
+  window.date = #{ raw Date.current.to_json }
   window.projects = #{ raw render 'projects.json.jbuilder', projects: @projects }
 = javascript_pack_tag 'activityInventory'


### PR DESCRIPTION
Reverts mokuo/pomodoro-rails#48

https://trello.com/c/XhHwpR0t/106-%E3%82%A2%E3%82%AF%E3%83%86%E3%82%A3%E3%83%93%E3%83%86%E3%82%A3%E5%9C%A8%E5%BA%AB%E3%82%B7%E3%83%BC%E3%83%88%E3%81%8B%E3%82%89%E6%9C%AC%E6%97%A5%E3%81%AEtodo%E3%81%B8%E3%81%AE%E7%A7%BB%E5%8B%95%E3%83%9C%E3%82%BF%E3%83%B3%E3%82%92%E6%8A%BC%E3%81%97%E3%81%A6%E3%82%82%E7%A7%BB%E5%8B%95%E3%81%95%E3%82%8C%E3%81%AA%E3%81%84

アクティビティ在庫シートの date state を null にした影響で、
アクティビティ在庫シートから本日のTODOへの移動ボタンを押しても移動されなくなった。
「アクティビティ在庫シートで追加したタスクが、本日のTODOになるバグを修正」は、別の方法でやる。